### PR TITLE
Remove nullable return type to provide PHP 7.0 support

### DIFF
--- a/app/SiteRepository.php
+++ b/app/SiteRepository.php
@@ -32,7 +32,7 @@ class SiteRepository
      * @param $slug
      * @return Site|null
      */
-    public function find($slug): ?Site
+    public function find($slug): Site
     {
         $this->load();
 


### PR DESCRIPTION
The nullable return type makes this demo unable to run on PHP 7.0. I suggest that's a bit premature. It is certainly the case that the omission of a nullable return type in PHP 7.0 is a design flaw, but them's the breaks.